### PR TITLE
[AUTH] 리프레쉬 토큰을 이용한 Access Token 재발급 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
@@ -38,6 +39,9 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    implementation 'io.jsonwebtoken:jjwt:0.12.6'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.4.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/spring_exam/auth/controller/AuthController.java
+++ b/src/main/java/com/example/spring_exam/auth/controller/AuthController.java
@@ -1,0 +1,28 @@
+package com.example.spring_exam.auth.controller;
+
+import com.example.spring_exam.auth.dto.UserTokenResponse;
+import com.example.spring_exam.auth.service.AuthService;
+import com.example.spring_exam.user.dto.LoginReq;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<UserTokenResponse> login(@Valid @RequestBody LoginReq req) {
+        UserTokenResponse token = authService.login(req);
+
+        return ResponseEntity.ok().body(token);
+    }
+}

--- a/src/main/java/com/example/spring_exam/auth/controller/AuthController.java
+++ b/src/main/java/com/example/spring_exam/auth/controller/AuthController.java
@@ -1,8 +1,11 @@
 package com.example.spring_exam.auth.controller;
 
+import com.example.spring_exam.auth.dto.AccessTokenResponse;
 import com.example.spring_exam.auth.dto.UserTokenResponse;
 import com.example.spring_exam.auth.service.AuthService;
+import com.example.spring_exam.common.response.CommonResponse;
 import com.example.spring_exam.user.dto.LoginReq;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,9 +23,27 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    public ResponseEntity<UserTokenResponse> login(@Valid @RequestBody LoginReq req) {
+    public CommonResponse<UserTokenResponse> login(@Valid @RequestBody LoginReq req) {
         UserTokenResponse token = authService.login(req);
 
-        return ResponseEntity.ok().body(token);
+        return CommonResponse.ok(token);
+    }
+
+    @PostMapping("/refresh")
+    public CommonResponse<AccessTokenResponse> generateAccessToken(HttpServletRequest request) {
+        String refreshToken = resolveToken(request);
+        AccessTokenResponse accessTokenResponse = authService.generateAccessToken(refreshToken);
+
+        return CommonResponse.created(accessTokenResponse);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+
+        String prefix = "Bearer ";
+        if (bearerToken != null && bearerToken.startsWith(prefix)) {
+            return bearerToken.substring(prefix.length());
+        }
+        return null;
     }
 }

--- a/src/main/java/com/example/spring_exam/auth/controller/AuthController.java
+++ b/src/main/java/com/example/spring_exam/auth/controller/AuthController.java
@@ -31,19 +31,10 @@ public class AuthController {
 
     @PostMapping("/refresh")
     public CommonResponse<AccessTokenResponse> generateAccessToken(HttpServletRequest request) {
-        String refreshToken = resolveToken(request);
+        String refreshToken = request.getHeader("Refresh-Token");
+
         AccessTokenResponse accessTokenResponse = authService.generateAccessToken(refreshToken);
 
         return CommonResponse.created(accessTokenResponse);
-    }
-
-    private String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-
-        String prefix = "Bearer ";
-        if (bearerToken != null && bearerToken.startsWith(prefix)) {
-            return bearerToken.substring(prefix.length());
-        }
-        return null;
     }
 }

--- a/src/main/java/com/example/spring_exam/auth/dto/AccessTokenResponse.java
+++ b/src/main/java/com/example/spring_exam/auth/dto/AccessTokenResponse.java
@@ -1,0 +1,15 @@
+package com.example.spring_exam.auth.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class AccessTokenResponse {
+    private String accessToken;
+}

--- a/src/main/java/com/example/spring_exam/auth/dto/UserTokenInfo.java
+++ b/src/main/java/com/example/spring_exam/auth/dto/UserTokenInfo.java
@@ -1,0 +1,9 @@
+package com.example.spring_exam.auth.dto;
+
+import com.example.spring_exam.user.domain.UserRole;
+
+public record UserTokenInfo(
+    Long id,
+    String username,
+    UserRole role
+) {}

--- a/src/main/java/com/example/spring_exam/auth/dto/UserTokenResponse.java
+++ b/src/main/java/com/example/spring_exam/auth/dto/UserTokenResponse.java
@@ -1,0 +1,16 @@
+package com.example.spring_exam.auth.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserTokenResponse {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/example/spring_exam/auth/service/AuthService.java
+++ b/src/main/java/com/example/spring_exam/auth/service/AuthService.java
@@ -1,0 +1,8 @@
+package com.example.spring_exam.auth.service;
+
+import com.example.spring_exam.auth.dto.UserTokenResponse;
+import com.example.spring_exam.user.dto.LoginReq;
+
+public interface AuthService {
+    UserTokenResponse login(LoginReq loginReq);
+}

--- a/src/main/java/com/example/spring_exam/auth/service/AuthService.java
+++ b/src/main/java/com/example/spring_exam/auth/service/AuthService.java
@@ -1,8 +1,11 @@
 package com.example.spring_exam.auth.service;
 
+import com.example.spring_exam.auth.dto.AccessTokenResponse;
 import com.example.spring_exam.auth.dto.UserTokenResponse;
 import com.example.spring_exam.user.dto.LoginReq;
 
 public interface AuthService {
     UserTokenResponse login(LoginReq loginReq);
+
+    AccessTokenResponse generateAccessToken(String accessToken);
 }

--- a/src/main/java/com/example/spring_exam/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/spring_exam/auth/service/AuthServiceImpl.java
@@ -1,0 +1,32 @@
+package com.example.spring_exam.auth.service;
+
+import com.example.spring_exam.auth.dto.UserTokenInfo;
+import com.example.spring_exam.auth.dto.UserTokenResponse;
+import com.example.spring_exam.auth.util.JwtUtil;
+import com.example.spring_exam.user.domain.User;
+import com.example.spring_exam.user.dto.LoginReq;
+import com.example.spring_exam.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenService refreshTokenService;
+    private final UserRepository userRepository;
+
+    @Override
+    public UserTokenResponse login(LoginReq loginReq) {
+        User user = userRepository.findByUsername(loginReq.username())
+                .orElseThrow(() -> new RuntimeException("사용자 정보가 없습니다."));
+        UserTokenInfo tokenInfo = new UserTokenInfo(user.getId(), user.getUsername(), user.getRole());
+
+        String accessToken = jwtUtil.createAccessToken(tokenInfo);
+        String refreshToken = jwtUtil.createRefreshToken(tokenInfo);
+
+        refreshTokenService.saveRefreshToken(user.getUsername(), refreshToken, jwtUtil.getRefreshTokenTTL());
+
+        return new UserTokenResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/example/spring_exam/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/spring_exam/auth/service/AuthServiceImpl.java
@@ -4,16 +4,21 @@ import com.example.spring_exam.auth.dto.AccessTokenResponse;
 import com.example.spring_exam.auth.dto.UserTokenInfo;
 import com.example.spring_exam.auth.dto.UserTokenResponse;
 import com.example.spring_exam.auth.util.JwtUtil;
+import com.example.spring_exam.auth.util.UserAuthenticator;
 import com.example.spring_exam.common.exception.auth.CustomJwtTokenException;
+import com.example.spring_exam.common.exception.auth.UnAuthenticatedException;
 import com.example.spring_exam.common.exception.auth.UnAuthorizedException;
+import com.example.spring_exam.common.exception.global.BadRequestException;
 import com.example.spring_exam.common.exception.user.UserNotFoundException;
 import com.example.spring_exam.common.response.ErrorCode;
 import com.example.spring_exam.user.domain.User;
 import com.example.spring_exam.user.dto.LoginReq;
 import com.example.spring_exam.user.repository.UserRepository;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -21,11 +26,15 @@ public class AuthServiceImpl implements AuthService {
     private final JwtUtil jwtUtil;
     private final RefreshTokenService refreshTokenService;
     private final UserRepository userRepository;
+    private final UserAuthenticator authenticator;
 
     @Override
     public UserTokenResponse login(LoginReq loginReq) {
         User user = userRepository.findByUsername(loginReq.username())
-                .orElseThrow(() -> new RuntimeException("사용자 정보가 없습니다."));
+                                    .orElseThrow(UserNotFoundException::new);
+        // 비밀번호 일치 검사
+        authenticator.authenticate(loginReq.password(), user.getPassword());
+
         UserTokenInfo tokenInfo = new UserTokenInfo(user.getId(), user.getUsername(), user.getRole());
 
         String accessToken = jwtUtil.createAccessToken(tokenInfo);
@@ -39,17 +48,15 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public AccessTokenResponse generateAccessToken(String refreshToken) {
         try {
-            if(!jwtUtil.validationToken(refreshToken)) {
-                throw new UnAuthorizedException();
+            if(!StringUtils.hasText(refreshToken)) {
+                throw new BadRequestException();
             }
-
-            // Redis에서 refresh Token 가져옴 (삭제되었다면 로그인 다시 필요)
-            String redisRefreshToken = refreshTokenService
-                    .getRefreshToken(refreshToken)
-                    .orElseThrow(UnAuthorizedException::new);
-
             // 만료되지 않은 토큰으로 사용자 명 조회
-            String username = jwtUtil.getUsernameByRefreshToken(redisRefreshToken);
+            String username = jwtUtil.getUsernameByRefreshToken(refreshToken);
+            // Redis에서 refresh Token 가져옴 (삭제되었다면 로그인 다시 필요)
+            refreshTokenService
+                .getRefreshToken(username)
+                .orElseThrow(UnAuthenticatedException::new);
 
             User user = userRepository.findByUsername(username)
                     .orElseThrow(UserNotFoundException::new);
@@ -63,6 +70,8 @@ public class AuthServiceImpl implements AuthService {
                     .accessToken(newAccessToken)
                     .build();
 
+        } catch (ExpiredJwtException e) {
+            throw new UnAuthorizedException();
         } catch (MalformedJwtException e) {
             throw new CustomJwtTokenException(ErrorCode.UNSUPPORTED_TOKEN);
         }

--- a/src/main/java/com/example/spring_exam/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/spring_exam/auth/service/AuthServiceImpl.java
@@ -1,11 +1,17 @@
 package com.example.spring_exam.auth.service;
 
+import com.example.spring_exam.auth.dto.AccessTokenResponse;
 import com.example.spring_exam.auth.dto.UserTokenInfo;
 import com.example.spring_exam.auth.dto.UserTokenResponse;
 import com.example.spring_exam.auth.util.JwtUtil;
+import com.example.spring_exam.common.exception.auth.CustomJwtTokenException;
+import com.example.spring_exam.common.exception.auth.UnAuthorizedException;
+import com.example.spring_exam.common.exception.user.UserNotFoundException;
+import com.example.spring_exam.common.response.ErrorCode;
 import com.example.spring_exam.user.domain.User;
 import com.example.spring_exam.user.dto.LoginReq;
 import com.example.spring_exam.user.repository.UserRepository;
+import io.jsonwebtoken.MalformedJwtException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -28,5 +34,37 @@ public class AuthServiceImpl implements AuthService {
         refreshTokenService.saveRefreshToken(user.getUsername(), refreshToken, jwtUtil.getRefreshTokenTTL());
 
         return new UserTokenResponse(accessToken, refreshToken);
+    }
+
+    @Override
+    public AccessTokenResponse generateAccessToken(String refreshToken) {
+        try {
+            if(!jwtUtil.validationToken(refreshToken)) {
+                throw new UnAuthorizedException();
+            }
+
+            // Redis에서 refresh Token 가져옴 (삭제되었다면 로그인 다시 필요)
+            String redisRefreshToken = refreshTokenService
+                    .getRefreshToken(refreshToken)
+                    .orElseThrow(UnAuthorizedException::new);
+
+            // 만료되지 않은 토큰으로 사용자 명 조회
+            String username = jwtUtil.getUsernameByRefreshToken(redisRefreshToken);
+
+            User user = userRepository.findByUsername(username)
+                    .orElseThrow(UserNotFoundException::new);
+
+            // 새 Access Token 발급
+            UserTokenInfo userTokenInfo = new UserTokenInfo(user.getId(), username, user.getRole());
+
+            String newAccessToken = jwtUtil.createAccessToken(userTokenInfo);
+
+            return AccessTokenResponse.builder()
+                    .accessToken(newAccessToken)
+                    .build();
+
+        } catch (MalformedJwtException e) {
+            throw new CustomJwtTokenException(ErrorCode.UNSUPPORTED_TOKEN);
+        }
     }
 }

--- a/src/main/java/com/example/spring_exam/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/example/spring_exam/auth/service/RefreshTokenService.java
@@ -1,0 +1,26 @@
+package com.example.spring_exam.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void saveRefreshToken(String username, String refreshToken, long ttlMillis) {
+        redisTemplate.opsForValue().set("refresh:" + username, refreshToken, ttlMillis, TimeUnit.MILLISECONDS);
+    }
+
+    public Optional<String> getRefreshToken(String username) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get("refresh:" + username));
+    }
+
+    public void deleteRefreshToken(String username) {
+        redisTemplate.delete("refresh:" + username);
+    }
+}

--- a/src/main/java/com/example/spring_exam/auth/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/spring_exam/auth/service/UserDetailsServiceImpl.java
@@ -1,0 +1,25 @@
+package com.example.spring_exam.auth.service;
+
+import com.example.spring_exam.common.exception.auth.CustomAuthException;
+import com.example.spring_exam.common.response.ErrorCode;
+import com.example.spring_exam.user.domain.User;
+import com.example.spring_exam.user.domain.UserDetailsImpl;
+import com.example.spring_exam.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomAuthException(ErrorCode.USER_NOT_FOUND));
+        return new UserDetailsImpl(user);
+    }
+}

--- a/src/main/java/com/example/spring_exam/auth/util/JwtUtil.java
+++ b/src/main/java/com/example/spring_exam/auth/util/JwtUtil.java
@@ -84,7 +84,6 @@ public class JwtUtil {
                 .build()
                 .parseSignedClaims(token)
                 .getPayload();
-
         return claims.getSubject();
     }
 

--- a/src/main/java/com/example/spring_exam/auth/util/JwtUtil.java
+++ b/src/main/java/com/example/spring_exam/auth/util/JwtUtil.java
@@ -1,0 +1,108 @@
+package com.example.spring_exam.auth.util;
+
+import com.example.spring_exam.auth.dto.UserTokenInfo;
+import com.example.spring_exam.user.domain.UserRole;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtUtil {
+    @Value("${exam.token.secretKey}")
+    private String secretKey;
+    @Value("${exam.token.accessTokenExpiration}")
+    private long accessTokenExpiration;
+    @Value("${exam.token.refreshTokenExpiration}")
+    private long refreshTokenExpiration;
+
+    @Value("${exam.token.issuer}")
+    private String issuer;
+
+    private SecretKey key;
+
+    @PostConstruct
+    public void initKey() {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String createAccessToken(UserTokenInfo user) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + accessTokenExpiration);
+
+        return Jwts.builder()
+                .subject(user.username())
+                .claim("id", user.id())
+                .claim("role", user.role())
+                .issuer(issuer)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(key)
+                .compact();
+    }
+
+    public String createRefreshToken(UserTokenInfo user) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + refreshTokenExpiration);
+
+        return Jwts.builder()
+                .subject(user.username())
+                .issuer(issuer)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(key)
+                .compact();
+    }
+
+    public UserTokenInfo getUserInfo(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        Long id = claims.get("id", Long.class);
+        String username = claims.getSubject();
+        String roleStr = claims.get("role", String.class);
+
+        return new UserTokenInfo(id, username, UserRole.fromString(roleStr));
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public long getRefreshTokenTTL() {
+        return refreshTokenExpiration;
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+
+        String prefix = "Bearer ";
+        if (bearerToken != null && bearerToken.startsWith(prefix)) {
+            return bearerToken.substring(prefix.length());
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/example/spring_exam/auth/util/JwtUtil.java
+++ b/src/main/java/com/example/spring_exam/auth/util/JwtUtil.java
@@ -3,7 +3,6 @@ package com.example.spring_exam.auth.util;
 import com.example.spring_exam.auth.dto.UserTokenInfo;
 import com.example.spring_exam.user.domain.UserRole;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -79,7 +78,17 @@ public class JwtUtil {
         return new UserTokenInfo(id, username, UserRole.fromString(roleStr));
     }
 
-    public boolean validateToken(String token) {
+    public String getUsernameByRefreshToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        return claims.getSubject();
+    }
+
+    public boolean validationToken(String token) {
         try {
             Jwts.parser()
                 .verifyWith(key)

--- a/src/main/java/com/example/spring_exam/auth/util/UserAuthenticator.java
+++ b/src/main/java/com/example/spring_exam/auth/util/UserAuthenticator.java
@@ -1,0 +1,18 @@
+package com.example.spring_exam.auth.util;
+
+import com.example.spring_exam.common.exception.auth.UnAuthenticatedException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserAuthenticator {
+    private final PasswordEncoder passwordEncoder;
+
+    public void authenticate(String rawPassword, String encodedPassword) {
+        if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
+            throw new UnAuthenticatedException();
+        }
+    }
+}

--- a/src/main/java/com/example/spring_exam/common/config/JacksonConfig.java
+++ b/src/main/java/com/example/spring_exam/common/config/JacksonConfig.java
@@ -1,0 +1,28 @@
+package com.example.spring_exam.common.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.text.SimpleDateFormat;
+
+@Configuration
+public class JacksonConfig {
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"));
+        mapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+        // 객체 -> JSON 직렬화
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        // JSON -> 객체 역직렬화
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        return mapper;
+    }
+}

--- a/src/main/java/com/example/spring_exam/common/config/RedisConfig.java
+++ b/src/main/java/com/example/spring_exam/common/config/RedisConfig.java
@@ -1,0 +1,42 @@
+package com.example.spring_exam.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        // Key-Value 형태
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        // Hash Key-Value 형태
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        // 기본적으로 직렬화를 수행
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/spring_exam/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/spring_exam/common/config/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
         http
             .csrf(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/api/user/signup", "/api/auth/login").permitAll()
+                .requestMatchers("/api/user/signup", "/api/auth/login", "/api/auth/refresh").permitAll()
                 .anyRequest().authenticated()
             )
             .formLogin(AbstractHttpConfigurer::disable);

--- a/src/main/java/com/example/spring_exam/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/spring_exam/common/config/SecurityConfig.java
@@ -1,0 +1,39 @@
+package com.example.spring_exam.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/user/signup", "/api/auth/login").permitAll()
+                .anyRequest().authenticated()
+            )
+            .formLogin(AbstractHttpConfigurer::disable);
+
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+}

--- a/src/main/java/com/example/spring_exam/common/enums/EnumCode.java
+++ b/src/main/java/com/example/spring_exam/common/enums/EnumCode.java
@@ -1,0 +1,21 @@
+package com.example.spring_exam.common.enums;
+
+import com.example.spring_exam.common.exception.AppException;
+import com.example.spring_exam.common.response.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public interface EnumCode {
+    @JsonValue
+    String getValue();
+
+    @JsonCreator
+    static <E extends Enum<E> & EnumCode> E fromValue(Class<E> enumType, String value) {
+        for (E enumConstant : enumType.getEnumConstants()) {
+            if (enumConstant.name().equalsIgnoreCase(value)) {
+                return enumConstant;
+            }
+        }
+        throw new AppException(ErrorCode.INVALID_INPUT_VALUE);
+    }
+}

--- a/src/main/java/com/example/spring_exam/common/exception/AppException.java
+++ b/src/main/java/com/example/spring_exam/common/exception/AppException.java
@@ -1,4 +1,4 @@
-package com.example.spring_exam.common.exception.auth;
+package com.example.spring_exam.common.exception;
 
 import com.example.spring_exam.common.response.ErrorCode;
 import lombok.Getter;

--- a/src/main/java/com/example/spring_exam/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/spring_exam/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,88 @@
+package com.example.spring_exam.common.exception;
+
+import com.example.spring_exam.common.response.CommonResponse;
+import com.example.spring_exam.common.response.ErrorCode;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // RequestBody & Valid 에서 발생
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<CommonResponse<Map<String, String>>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+
+        ex.getBindingResult().getFieldErrors().forEach(error -> {
+            errors.put(error.getField(), error.getDefaultMessage());
+        });
+
+        ErrorCode invalidInputValue = ErrorCode.INVALID_INPUT_VALUE;
+
+        return getResponse(invalidInputValue.getHttpStatus(), invalidInputValue, errors);
+    }
+
+    // @ModelAttribute & @Valid 에서 발생
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<CommonResponse<Map<String, String>>> handleBindException(BindException ex) {
+        Map<String, String> errors = new HashMap<>();
+
+        ex.getBindingResult().getFieldErrors().forEach(error -> {
+            errors.put(error.getField(), error.getDefaultMessage());
+        });
+
+        ErrorCode invalidInputValue = ErrorCode.INVALID_INPUT_VALUE;
+
+        return getResponse(invalidInputValue.getHttpStatus(), invalidInputValue, errors);
+    }
+
+    // @RequestParam 같은 단일 값 유효성 실패 시 발생
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<CommonResponse<Map<String, String>>> handleConstraintViolationException(ConstraintViolationException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getConstraintViolations().forEach(violation -> {
+            String field = violation.getPropertyPath().toString();
+            errors.put(field, violation.getMessage());
+        });
+
+        ErrorCode invalidInputValue = ErrorCode.INVALID_INPUT_VALUE;
+        return getResponse(invalidInputValue.getHttpStatus(), invalidInputValue);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CommonResponse<Map<String, String>>> handleAllExceptions(Exception ex) {
+        ErrorCode internalServerError = ErrorCode.INTERNAL_SERVER_ERROR;
+
+        Map<String, String> error = new HashMap<>();
+        error.put("error", ex.getMessage());
+
+        return getResponse(internalServerError.getHttpStatus(), internalServerError, error);
+    }
+
+
+    private <T> ResponseEntity<CommonResponse<T>> getResponse(HttpStatus status, ErrorCode errorCode, T data) {
+        if (data != null) {
+            return ResponseEntity
+                    .status(status)
+                    .body(CommonResponse.fail(data, errorCode));
+        } else {
+            return ResponseEntity
+                    .status(status)
+                    .body(CommonResponse.fail(errorCode));
+        }
+    }
+
+    private <T> ResponseEntity<CommonResponse<T>> getResponse(HttpStatus status, ErrorCode errorCode) {
+        return ResponseEntity
+                .status(status)
+                .body(CommonResponse.fail(errorCode));
+    }
+}

--- a/src/main/java/com/example/spring_exam/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/spring_exam/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,8 @@
 package com.example.spring_exam.common.exception;
 
+import com.example.spring_exam.common.exception.auth.UnAuthenticatedException;
+import com.example.spring_exam.common.exception.auth.UnAuthorizedException;
+import com.example.spring_exam.common.exception.global.BadRequestException;
 import com.example.spring_exam.common.response.CommonResponse;
 import com.example.spring_exam.common.response.ErrorCode;
 import jakarta.validation.ConstraintViolationException;
@@ -55,6 +58,34 @@ public class GlobalExceptionHandler {
 
         ErrorCode invalidInputValue = ErrorCode.INVALID_INPUT_VALUE;
         return getResponse(invalidInputValue.getHttpStatus(), invalidInputValue);
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<CommonResponse<Map<String, String>>> handleAllExceptions(BadRequestException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        return getResponse(errorCode.getHttpStatus(), errorCode);
+    }
+
+    @ExceptionHandler(UnAuthorizedException.class)
+    public ResponseEntity<CommonResponse<Map<String, String>>> handleAllExceptions(UnAuthorizedException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        return getResponse(errorCode.getHttpStatus(), errorCode);
+    }
+
+    @ExceptionHandler(UnAuthenticatedException.class)
+    public ResponseEntity<CommonResponse<Map<String, String>>> handleAllExceptions(UnAuthenticatedException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        return getResponse(errorCode.getHttpStatus(), errorCode);
+    }
+
+    @ExceptionHandler(AppException.class)
+    public ResponseEntity<CommonResponse<Map<String, String>>> handleAllExceptions(AppException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+
+        Map<String, String> error = new HashMap<>();
+        error.put("error", ex.getMessage());
+
+        return getResponse(errorCode.getHttpStatus(), errorCode, error);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/example/spring_exam/common/exception/auth/CustomJwtTokenException.java
+++ b/src/main/java/com/example/spring_exam/common/exception/auth/CustomJwtTokenException.java
@@ -3,12 +3,13 @@ package com.example.spring_exam.common.exception.auth;
 import com.example.spring_exam.common.exception.AppException;
 import com.example.spring_exam.common.response.ErrorCode;
 
-public class CustomAuthException extends AppException {
-    public CustomAuthException(ErrorCode errorCode) {
+public class CustomJwtTokenException extends AppException {
+
+    public CustomJwtTokenException(ErrorCode errorCode) {
         super(errorCode);
     }
 
-    public CustomAuthException(int statusCode) {
+    public CustomJwtTokenException(int statusCode) {
         super(statusCode);
     }
 }

--- a/src/main/java/com/example/spring_exam/common/exception/auth/UnAuthenticatedException.java
+++ b/src/main/java/com/example/spring_exam/common/exception/auth/UnAuthenticatedException.java
@@ -1,0 +1,14 @@
+package com.example.spring_exam.common.exception.auth;
+
+import com.example.spring_exam.common.exception.AppException;
+import com.example.spring_exam.common.response.ErrorCode;
+
+public class UnAuthenticatedException extends AppException {
+    public UnAuthenticatedException() {
+        super(ErrorCode.UNAUTHENTICATED_USER);
+    }
+
+    public UnAuthenticatedException(int statusCode) {
+        super(statusCode);
+    }
+}

--- a/src/main/java/com/example/spring_exam/common/exception/auth/UnAuthorizedException.java
+++ b/src/main/java/com/example/spring_exam/common/exception/auth/UnAuthorizedException.java
@@ -3,12 +3,12 @@ package com.example.spring_exam.common.exception.auth;
 import com.example.spring_exam.common.exception.AppException;
 import com.example.spring_exam.common.response.ErrorCode;
 
-public class CustomAuthException extends AppException {
-    public CustomAuthException(ErrorCode errorCode) {
-        super(errorCode);
+public class UnAuthorizedException extends AppException {
+    public UnAuthorizedException() {
+        super(ErrorCode.UNAUTHORIZED_ACCESS);
     }
 
-    public CustomAuthException(int statusCode) {
+    public UnAuthorizedException(int statusCode) {
         super(statusCode);
     }
 }

--- a/src/main/java/com/example/spring_exam/common/exception/global/BadRequestException.java
+++ b/src/main/java/com/example/spring_exam/common/exception/global/BadRequestException.java
@@ -1,0 +1,19 @@
+package com.example.spring_exam.common.exception.global;
+
+import com.example.spring_exam.common.exception.AppException;
+import com.example.spring_exam.common.response.ErrorCode;
+
+public class BadRequestException extends AppException {
+
+    public BadRequestException() {
+        super(ErrorCode.INVALID_INPUT_VALUE);
+    }
+
+    public BadRequestException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public BadRequestException(int statusCode) {
+        super(statusCode);
+    }
+}

--- a/src/main/java/com/example/spring_exam/common/exception/user/UserNotFoundException.java
+++ b/src/main/java/com/example/spring_exam/common/exception/user/UserNotFoundException.java
@@ -1,0 +1,14 @@
+package com.example.spring_exam.common.exception.user;
+
+import com.example.spring_exam.common.exception.AppException;
+import com.example.spring_exam.common.response.ErrorCode;
+
+public class UserNotFoundException extends AppException {
+    public UserNotFoundException() {
+        super(ErrorCode.USER_NOT_FOUND);
+    }
+
+    public UserNotFoundException(int statusCode) {
+        super(statusCode);
+    }
+}

--- a/src/main/java/com/example/spring_exam/common/filter/JwtAuthFilter.java
+++ b/src/main/java/com/example/spring_exam/common/filter/JwtAuthFilter.java
@@ -1,0 +1,68 @@
+package com.example.spring_exam.common.filter;
+
+import com.example.spring_exam.auth.dto.UserTokenInfo;
+import com.example.spring_exam.auth.service.RefreshTokenService;
+import com.example.spring_exam.auth.service.UserDetailsServiceImpl;
+import com.example.spring_exam.auth.util.JwtUtil;
+import com.example.spring_exam.common.response.CommonResponse;
+import com.example.spring_exam.common.response.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+    private final UserDetailsServiceImpl userDetailsService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String accessToken = jwtUtil.resolveToken(request);
+
+        if (accessToken != null) {
+            try {
+                UserTokenInfo userInfo = jwtUtil.getUserInfo(accessToken);
+
+                response.setHeader("Authorization", "Bearer " + accessToken);
+                SecurityContextHolder.getContext().setAuthentication(
+                        new UsernamePasswordAuthenticationToken(userInfo, null, null)
+                );
+
+            } catch (ExpiredJwtException e) {
+                // 토큰이 만료되었을 때 요청 속성에 더 자세한 정보를 담아서 전달
+                request.setAttribute("expired", true);
+                request.setAttribute("expiredToken", accessToken); // 만료된 토큰 정보
+                request.setAttribute("expiredTokenClaims", e.getClaims()); // 만료된 토큰의 클레임 정보
+            } catch (Exception e) {
+                handleInvalidToken(response, e);
+                return;
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private void handleInvalidToken(HttpServletResponse response, Exception e) throws IOException {
+        log.error("유효하지 않은 토큰", e);
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        CommonResponse<Void> errorResponse = CommonResponse.fail(ErrorCode.INVALID_TOKEN);
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/example/spring_exam/common/response/CommonResponse.java
+++ b/src/main/java/com/example/spring_exam/common/response/CommonResponse.java
@@ -1,0 +1,26 @@
+package com.example.spring_exam.common.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.springframework.http.HttpStatus;
+import org.springframework.lang.Nullable;
+
+public record CommonResponse<T>(
+        @JsonIgnore
+        HttpStatus httpStatus,
+        boolean success,
+        @Nullable T data,
+        @Nullable ExceptionRes error
+) {
+
+    public static <T> CommonResponse<T> ok(@Nullable final T data) {
+        return new CommonResponse<>(HttpStatus.OK, true, data, null);
+    }
+
+    public static <T> CommonResponse<T> created(@Nullable final T data) {
+        return new CommonResponse<>(HttpStatus.CREATED, true, data, null);
+    }
+
+    public static <T> CommonResponse<T> fail(final ErrorCode c) {
+        return new CommonResponse<>(c.getHttpStatus(), false, null, ExceptionRes.of(c));
+    }
+}

--- a/src/main/java/com/example/spring_exam/common/response/CommonResponse.java
+++ b/src/main/java/com/example/spring_exam/common/response/CommonResponse.java
@@ -23,4 +23,8 @@ public record CommonResponse<T>(
     public static <T> CommonResponse<T> fail(final ErrorCode c) {
         return new CommonResponse<>(c.getHttpStatus(), false, null, ExceptionRes.of(c));
     }
+
+    public static <T> CommonResponse<T> fail(final T data, final ErrorCode c) {
+        return new CommonResponse<>(c.getHttpStatus(), false, data, ExceptionRes.of(c));
+    }
 }

--- a/src/main/java/com/example/spring_exam/common/response/ErrorCode.java
+++ b/src/main/java/com/example/spring_exam/common/response/ErrorCode.java
@@ -28,7 +28,8 @@ public enum ErrorCode implements EnumCode {
     UNSUPPORTED_TOKEN(40102, HttpStatus.UNAUTHORIZED, "지원되지 않는 토큰입니다."),
     WRONG_TOKEN(40103, HttpStatus.UNAUTHORIZED, "잘못된 토큰입니다."),
     EMPTY_TOKEN(40104, HttpStatus.UNAUTHORIZED, "토큰이 비어있습니다."),
-    UNAUTHORIZED_ACCESS(40105, HttpStatus.UNAUTHORIZED, "인증되지 않은 접근입니다."),
+    UNAUTHORIZED_ACCESS(40105, HttpStatus.UNAUTHORIZED, "인가되지 않은 접근입니다."),
+    UNAUTHENTICATED_USER(40105, HttpStatus.FORBIDDEN, "인증되지 않은 사용자입니다."),
     FORBIDDEN_ACCESS_ADMIN(40300, HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."),
 
     ;

--- a/src/main/java/com/example/spring_exam/common/response/ExceptionRes.java
+++ b/src/main/java/com/example/spring_exam/common/response/ExceptionRes.java
@@ -1,0 +1,15 @@
+package com.example.spring_exam.common.response;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ExceptionRes(
+    @NotNull Integer code,
+    @NotNull String message) {
+
+    public static ExceptionRes of(ErrorCode errorCode) {
+        return new ExceptionRes(
+                errorCode.getCode(),
+                errorCode.getMessage()
+        );
+    }
+}

--- a/src/main/java/com/example/spring_exam/common/util/RedisHealthChecker.java
+++ b/src/main/java/com/example/spring_exam/common/util/RedisHealthChecker.java
@@ -1,0 +1,54 @@
+package com.example.spring_exam.common.util;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisHealthChecker {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @PostConstruct
+    public void checkRedisOnStartup() {
+        try {
+            if (isRedisAvailable()) {
+                log.info("Redis 연결됨 ✅ ");
+            } else {
+                log.warn("Redis 연결 불가. 일부 기능이 제한될 수 있습니다. ❗ ");
+            }
+        } catch (Exception e) {
+            log.error("Redis 초기 점검 실패: {}", e.getMessage());
+        }
+    }
+
+    public boolean isRedisAvailable() {
+        try {
+            Optional<RedisConnectionFactory> factory = Optional.ofNullable(redisTemplate.getConnectionFactory());
+            if (factory.isEmpty()) {
+                log.warn("RedisConnectionFactory가 null입니다.");
+                return false;
+            }
+
+            Optional<RedisConnection> connection = Optional.of(factory.get().getConnection());
+            String ping = connection.get().ping();
+
+            return RedisHealthCheckType.PONG.name().equalsIgnoreCase(ping);
+        } catch (Exception e) {
+            log.error("Redis 상태 점검 실패: {}", e.getMessage());
+            return false;
+        }
+    }
+}
+
+enum RedisHealthCheckType {
+    PING,
+    PONG,
+}

--- a/src/main/java/com/example/spring_exam/user/domain/UserDetailsImpl.java
+++ b/src/main/java/com/example/spring_exam/user/domain/UserDetailsImpl.java
@@ -1,0 +1,49 @@
+package com.example.spring_exam.user.domain;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public record UserDetailsImpl(User user) implements UserDetails {
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(user.getRole().name()));
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return user.isAccountNonExpired();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return user.isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return user.isCredentialsNonExpired();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return user.isEnabled();
+    }
+}

--- a/src/test/java/com/example/spring_exam/auth/AuthTest.java
+++ b/src/test/java/com/example/spring_exam/auth/AuthTest.java
@@ -1,0 +1,127 @@
+package com.example.spring_exam.auth;
+
+import com.example.spring_exam.auth.dto.UserTokenResponse;
+import com.example.spring_exam.common.response.CommonResponse;
+import com.example.spring_exam.user.dto.LoginReq;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+public class AuthTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("로그인")
+    void login() throws Exception {
+        LoginReq testuser2 = new LoginReq("testuser2", "Test1234!2");
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(testuser2)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.access_token").exists())
+                .andExpect(jsonPath("$.data.refresh_token").exists());
+    }
+    
+    @Test
+    @DisplayName("refresh 토큰을 이용한 Access 토큰 재발급 성공")
+    void 만료시_AccessToken_재발행_성공() throws Exception {
+
+        LoginReq testuser2 = new LoginReq("testuser2", "Test1234!2");
+
+        // 로그인 요청 수행 후 응답에서 추출
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(testuser2)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String responseBody = loginResult.getResponse().getContentAsString();
+
+        JavaType type = objectMapper.getTypeFactory()
+                .constructParametricType(CommonResponse.class, UserTokenResponse.class);
+
+        CommonResponse<UserTokenResponse> result = objectMapper.readValue(responseBody, type);
+
+        // accessToken 만료까지 sleep 테스트 yml의 Access 토큰 만료시간은 5초
+        Thread.sleep(6000);
+
+        UserTokenResponse userTokenResponse = result.data();
+
+        assertNotNull(userTokenResponse, "로그인 한 뒤의 토큰 값은 Null이면 안 됨");
+        assertNotNull(userTokenResponse.getAccessToken(), "로그인 한 뒤의 Access 토큰 값은 Null 이면 안 됨");
+        assertNotNull(userTokenResponse.getRefreshToken(), "로그인 한 뒤의 Refresh 토큰 값은 Null 이면 안 됨");
+
+        // refresh 재발급 요청 및 검증
+        mockMvc.perform(
+            post("/api/auth/refresh")
+            .contentType(MediaType.APPLICATION_JSON)
+            .header("Authorization", "Bearer " + userTokenResponse.getAccessToken())
+            .header("Refresh-Token", userTokenResponse.getRefreshToken()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.access_token").exists())
+            ;
+    }
+
+    @Test
+    @DisplayName("refresh 토큰을 이용한 Access 토큰 재발급 실패 - refresh 만료")
+    void 만료시_AccessToken_재발행_실패() throws Exception {
+        LoginReq testuser2 = new LoginReq("testuser2", "Test1234!2");
+
+        // 로그인 요청 수행 후 응답에서 추출
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(testuser2)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String responseBody = loginResult.getResponse().getContentAsString();
+
+        JavaType type = objectMapper.getTypeFactory()
+                .constructParametricType(CommonResponse.class, UserTokenResponse.class);
+
+        CommonResponse<UserTokenResponse> result = objectMapper.readValue(responseBody, type);
+
+        UserTokenResponse userTokenResponse = result.data();
+
+        // refresh 토큰 만료시키기
+        Thread.sleep(5000);
+
+        assertNotNull(userTokenResponse, "로그인 한 뒤의 토큰 값은 Null이면 안 됨");
+        assertNotNull(userTokenResponse.getAccessToken(), "로그인 한 뒤의 Access 토큰 값은 Null 이면 안 됨");
+        assertNotNull(userTokenResponse.getRefreshToken(), "로그인 한 뒤의 Refresh 토큰 값은 Null 이면 안 됨");
+
+        // refresh 재발급 요청 및 검증
+        mockMvc.perform(
+                post("/api/auth/refresh")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + userTokenResponse.getAccessToken())
+                    .header("Refresh-Token", userTokenResponse.getRefreshToken()))
+        .andExpect(status().isUnauthorized())
+        ;
+    }
+}


### PR DESCRIPTION
Description 🔍
- 로그인 기능 추가 ( id / password 기반)
- access token이 만료 되었을 때 refresh 토큰을 이용해 재발급 하는 기능이 필요
- 토큰이 없을 때 (만료, 없음)는 미 인증처리로 로그인 다시할 수 있게 처리
- localhost 에서의 Redis에 refresh Token을 저장해 사용자 토큰 처리
- 전역적으로 에러 핸들링 할 수 있게 추가
- custom exception 클래스 추가
- 공통 반환객체 추가해 API 규격 단일화
Changes ⚡
- jwt 의존성 추가
- 비밀번호 일치 여부를 판별하는 UserAuthenticator 추가
- objectMapper 빈 등록
- Redis 설정 추가
- Security 설정 추가 
  - TODO 전역적으로 접근 가능한 url을 별도로 분리  
 
Screenshots 📷
Ref
Notion Link:
Figma Link:
Docs link: